### PR TITLE
chore: use node20 instead of node12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: the msg content https://www.feishu.cn/hc/zh-CN/articles/360024984973
 
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
The node12 is deprecated and will be replaced by node16, we can bump the version to node20 directly.

[Update runtime](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)